### PR TITLE
Update bower version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
   "name": "stampit",
-  "version": "0.2.3",
+  "version": "0.3.3",
   "main": "./dist/stampit.js"
 }


### PR DESCRIPTION
Hi!

Could you please update the bower version of stampit to 0.3.3 and add according tag to the repo? Version 0.3.2 seems to be broken.
