### PR TITLE
Detach `stamp.static()` and `stamp.compose()` from `this`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test": "npm run hint && node test/index.js",
     "clean": "rimraf dist/* && mkdir dist || true",
     "uglify": "uglifyjs dist/stampit.js -m -c warnings=false -o dist/stampit.min.js",
-    "hint": "jshint stampit.js mixer.js test/ && echo JSHint: linting successful",
+    "hint": "jshint stampit.js test/ && echo JSHint: linting successful",
     "build": "npm run clean && browserify stampit.js -s stampit -o dist/stampit.js && npm run uglify"
   },
   "license": "MIT"

--- a/stampit.js
+++ b/stampit.js
@@ -196,7 +196,7 @@ stampit = function stampit(options) {
      * @return {Function} A new stamp (factory object).
      */
     static: function () {
-      var newStamp = cloneAndExtend(this.fixed, addStatic, slice(arguments));
+      var newStamp = cloneAndExtend(factory.fixed, addStatic, slice(arguments));
       return mixer.mixin(newStamp, newStamp.fixed.static);
     },
 
@@ -209,7 +209,7 @@ stampit = function stampit(options) {
      */
     compose: function (factories) {
       var args = isArray(factories) ? factories : slice(arguments);
-      args = [this].concat(args);
+      args = [factory].concat(args);
       return compose(args);
     }
   }, fixed.static);


### PR DESCRIPTION
Use closure variable instead of `this`. Stamp function should not depend on bound context. This improves code stability. Stamp behavior gets more predictable.