### PR TITLE
Support automatic releases to CDNJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,15 @@
     "lint": "eslint src && eslint test",
     "build": "npm run clean && babel src --out-dir dist && npm run uglify"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "npmName": "stampit",
+  "npmFileMap": [
+    {
+      "basePath": "/dist/",
+      "files": [
+        "stampit.js",
+        "stampit.min.js"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
See https://github.com/ericelliott/prod-module-boilerplate/issues/18

When this is merged, PR to https://github.com/cdnjs/cdnjs/ should be made (with cdnjs-importer tool), so the existing stampit there is updated with new config. Then every new NPM release will be automatically published on CDNJS.