### PR TITLE
Implement "static" properties in the convertConstructor.

### DIFF
--- a/src/stampit.js
+++ b/src/stampit.js
@@ -219,6 +219,7 @@ function isStamp(obj) {
 function convertConstructor(Constructor) {
   const stamp = stampit();
   stamp.fixed.refs = stamp.fixed.state = mergeChainNonFunctions(stamp.fixed.refs, Constructor.prototype);
+  mixin(stamp, mixin(stamp.fixed.static, Constructor));
 
   mixinChainFunctions(stamp.fixed.methods, Constructor.prototype);
   addInit(stamp.fixed, ({ instance, args }) => Constructor.apply(instance, args));

--- a/test/convert-constructor.js
+++ b/test/convert-constructor.js
@@ -19,11 +19,11 @@ test('stampit.convertConstructor()', (t) => {
   t.equal(obj.thing, 'initialized',
     'Constructor should execute.');
 
-  t.equal(obj.staticFunc, undefined,
-    'Non prototype functions should not be mixed in.');
+  t.equal(oldskool.staticFunc, Constructor.staticFunc,
+    'Non prototype functions should be mixed to stamp.');
 
-  t.equal(obj.staticProp, undefined,
-    'Non prototype properties should not be mixed in.');
+  t.equal(oldskool.staticProp, 'static',
+    'Non prototype properties should be mixed to stamp.');
 
   t.equal(obj.foo && obj.foo(), 'foo',
     'Constructor prototype should be mixed in.');
@@ -51,6 +51,8 @@ test('stampit.convertConstructor() composed', (t) => {
   };
   Constructor.prototype = new Base();
   Constructor.prototype.foo = () => { return 'foo'; };
+  Constructor.staticFunc = () => {};
+  Constructor.staticProp = 'static';
 
   // The conversion
   const oldskool = stampit.convertConstructor(Constructor);
@@ -121,6 +123,18 @@ test('stampit.convertConstructor() composed', (t) => {
 
   t.equal(u.baseOfBaseFunc && u.baseOfBaseFunc(), 'baseOfBaseFunc',
     'Prototype chain function should be mixed in.');
+
+  t.equal(myThing.staticFunc, Constructor.staticFunc,
+    'Non prototype functions should be mixed to stamp.');
+
+  t.equal(myThing.staticProp, 'static',
+    'Non prototype properties should be mixed to stamp.');
+
+  t.equal(myThing2.staticFunc, Constructor.staticFunc,
+    'Non prototype functions should be mixed to stamp.');
+
+  t.equal(myThing2.staticProp, 'static',
+    'Non prototype properties should be mixed to stamp.');
 
   t.end();
 });


### PR DESCRIPTION
See #128 

"static" properties from the old school constructors are copied to stamp as expected.
```js
function SomeClassLikeFunction() {}
SomeClassLikeFunction.staticProperty = function () {};
var stamp = stampit.convertConstructor(SomeClassLikeFunction);
stamp.staticProperty(); // ALL GOOD!
```