### PR TITLE
Fix README code samples by replacing `this` with `instance`

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Basic questions like "how do I inherit privileged methods and private data?" and
 Let's answer both of these questions at the same time. First, we'll use a closure to create data privacy:
 
 ```js
-const a = stampit().init(function () {
+const a = stampit().init(() => {
   const priv = 'a';
   this.getA = () => {
     return priv;
@@ -135,7 +135,7 @@ because we didn't assign it to anything. Don't worry about that.
 Here's another:
 
 ```js
-const b = stampit().init(function () {
+const b = stampit().init(() => {
   const priv = 'b';
   this.getB = () => {
     return priv;
@@ -162,7 +162,7 @@ But that's boring. Let's see what else is on tap:
 
 ```js
 // Some more privileged methods, with some private data.
-const availability = stampit().init(() => {
+const availability = stampit().init(({instance}) => {
   var isOpen = false; // private
 
   instance.open = function open() {


### PR DESCRIPTION
I couldn't understand why the samples didn't want to work on my machine! After reading the API docs I realised they were wrong...