### PR TITLE
Fix build issues related to NPM 3 flat structure

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -9,16 +9,13 @@ import uglify from 'rollup-plugin-uglify';
 // This code reimplements the "babel-preset-es2015-rollup" module.
 // But also does not include "external-helpers" babel plugin.
 // That plugin made the code too large and also is hard to configure.
-const es2015Plugins = Object.keys(
-  require('../node_modules/babel-preset-es2015/package.json')
-  .dependencies)
-  // This plugin must be excluded for rollup. Otherwise, it doesn't work.
-  .filter(dep =>
-    dep !== 'babel-plugin-transform-es2015-modules-commonjs' &&
-    dep !== 'babel-plugin-transform-es2015-typeof-symbol'
+const es2015Plugins = 
+  Object.keys(
+    require('../node_modules/babel-preset-es2015/package.json').dependencies
   )
-  .map(dep => '../node_modules/babel-preset-es2015/node_modules/' + dep)
-  .map(require);
+  // Rollup recognizes ES6 modules, not need to transpile that
+  .filter(dep => dep !== 'babel-plugin-transform-es2015-modules-commonjs')
+;
 
 const moduleName = 'stampit';
 


### PR DESCRIPTION
I believe this is a reason of failed tests, because Node V5 & V6 are using NPM V3 with flat node_modules. The babel simply accepts list of names of plugins, you don't need to specify path there or even require that module, it will handle it properly.

I am also trying to keep `typeof-symbol` plugin there as I cannot imagine why it's failing. If you are right, I will put it back.