### PR TITLE
Add link to medium articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Looking for a deep dive into prototypal OO, stamps, and the Two Pillars of JavaS
 
 **React Users.** Stampit *loves* React. Check out [react-stamp](https://github.com/stampit-org/react-stamp) for composable components.
 
-Check out [Fun with stamps](https://medium.com/@koresar/fun-with-stamps-episode-1-stamp-basics-e0627d81efe0#.d3j78cb2p), a series of articles explaining the basics of stamps along with some advanced topics.
+Check out [Fun With Stamps](https://medium.com/@koresar/fun-with-stamps-episode-1-stamp-basics-e0627d81efe0), a series of articles explaining the basics of stamps along with some advanced topics.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Looking for a deep dive into prototypal OO, stamps, and the Two Pillars of JavaS
 
 **React Users.** Stampit *loves* React. Check out [react-stamp](https://github.com/stampit-org/react-stamp) for composable components.
 
+Check out series of articles explaining stamps basics and following with some advanced topics: [Fun with stamps](https://medium.com/@koresar/fun-with-stamps-episode-1-stamp-basics-e0627d81efe0#.d3j78cb2p)
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Looking for a deep dive into prototypal OO, stamps, and the Two Pillars of JavaS
 
 **React Users.** Stampit *loves* React. Check out [react-stamp](https://github.com/stampit-org/react-stamp) for composable components.
 
-Check out series of articles explaining stamps basics and following with some advanced topics: [Fun with stamps](https://medium.com/@koresar/fun-with-stamps-episode-1-stamp-basics-e0627d81efe0#.d3j78cb2p)
+Check out [Fun with stamps](https://medium.com/@koresar/fun-with-stamps-episode-1-stamp-basics-e0627d81efe0#.d3j78cb2p), a series of articles explaining the basics of stamps along with some advanced topics.
 
 ## Status
 


### PR DESCRIPTION
Apparently documentation is not enough and finding those articles is not that easy. I am pushing this intentionally to master branch as that's what people will see when coming to repo.