### PR TITLE
Update advanced_examples.md

### DIFF
--- a/docs/advanced_examples.md
+++ b/docs/advanced_examples.md
@@ -303,13 +303,13 @@ const JoiPrevalidator = stampit
   .init(function () { // This will be called for each new object instance.
     _.forOwn(this.prevalidations, (value, key) => { // overriding functions
       const actualFunc = this[key];
-      this[key] = () => { // Overwrite a real function with ours.
+      this[key] = ( ...args ) => { // Overwrite a real function with ours.
         const result = joi.validate(this, value, {allowUnknown: true});
         if (result.error) {
           throw new Error(`Can't call ${key}(), prevalidation failed: ${result.error}`);
         }
 
-        return actualFunc.apply(this, arguments);
+        return actualFunc.apply(this, args);
       }
     });
   });


### PR DESCRIPTION
The docs can be misleading for people who use this example. 

Arrow functions do not expose an 'arguments' object, the only reason the example works is due to babel.

A better example is to use the correct es6 syntax, by using [rest parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters).