### PR TITLE
Fix some lint issues and update airbnb

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,6 @@
     "comma-dangle": 0,
     "no-confusing-arrow": 0,
     "prefer-rest-params": 0,
-    "no-use-before-define": 1,
-    "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }]
+    "no-use-before-define": [2, "nofunc"],
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "check-compose": "^3.2.0",
     "dependency-check": "^2.5.0",
     "eslint": "^3.5.0",
-    "eslint-config-airbnb-base": "^7.1.0",
+    "eslint-config-airbnb-base": "7.1.0",
     "eslint-plugin-import": "^1.15.0",
     "isparta": "^4.0.0",
     "lodash": "^4.16.1",

--- a/src/extract-functions.js
+++ b/src/extract-functions.js
@@ -2,7 +2,7 @@ import isFunction from './isFunction';
 
 export default function (...args) {
   let result = [];
-  for (let i = 0; i < args.length; i++) {
+  for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     if (isFunction(arg)) result.push(arg);
     else if (Array.isArray(arg)) result = result.concat(arg.filter(isFunction));

--- a/src/merge.js
+++ b/src/merge.js
@@ -23,7 +23,7 @@ function mergeOne(dst, src) {
   const returnValue = isObject(dst) ? dst : {};
 
   const keys = Object.keys(src);
-  for (let i = 0; i < keys.length; i++) {
+  for (let i = 0; i < keys.length; i += 1) {
     const key = keys[i];
 
     const srcValue = src[key];


### PR DESCRIPTION
I've replaced for loops using `++` operator with `reduce` which I would say is better in general.

Change for a rule "no-use-before-define" allows hoisting of functions which is necessary to pass with green lights :)

Updated airbnb since it was complaining about new version of eslint. Nothing for broken because of that.