### PR TITLE
.npmignore - make the NPM package 3 time smaller

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,4 +7,3 @@
 /coverage/
 /build/
 /src/
-/docs/

--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,10 @@
-.editorconfig
-.publishrc
-.idea/
-/*.tgz
+/.babelrc
+/.editorconfig
+/.eslintrc
+/.npmignore
 /.travis.yml
-/.jshintrc
-/buildconfig.env.example
 /test/
+/coverage/
+/build/
+/src/
+/docs/


### PR DESCRIPTION
1. Remove files and folders we no longer have
2. Ignore all the dev "dot" files: babelrc, eslintrc, npmignore
3. Ignore `/coverage` (yeah, I published that folder to NPM)
4. Ignore `/build` as a dev file
5. Ignore `/src` because we have the `/dist` folder having the full `/src` in various formats
6. Ignore `/docs` because they are not recommended to be part of a distributable module

All the items here are discussable.

P.S. This reduces the packages by ~3 times (from 60K to 21K). Removing the docs only shrinks the npm tarball by 10K. Removing the coverage does roughly the same.