### PR TITLE
Remove "babel" field in package.json for react-native support

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -13,7 +13,9 @@ import MagicString from 'magic-string';
 // That plugin made the code too large and also is hard to configure.
 // The main idea is to make sure babel does not transpile ES6 modules to CJS
 // because Rollup handles import/export itself.
-const es2015Plugins = pkg.babel.plugins;
+const es2015Presets = [
+  ['es2015', {loose: true, modules: false}]
+];
 
 const moduleName = 'stampit';
 
@@ -25,7 +27,7 @@ function execute() {
       {
         format: 'cjs',
         ext: '.full.js',
-        babelPlugins: es2015Plugins,
+        babelPresets: es2015Presets,
         dest: 'dist',
         moduleName: 'stampit'
       }
@@ -36,7 +38,7 @@ function execute() {
       {
         format: 'umd',
         ext: '.umd.js',
-        babelPlugins: es2015Plugins,
+        babelPresets: es2015Presets,
         dest: 'dist',
         moduleName: 'stampit'
       }
@@ -48,7 +50,7 @@ function execute() {
         format: 'umd',
         ext: '.umd.min.js',
         minify: true,
-        babelPlugins: es2015Plugins,
+        babelPresets: es2015Presets,
         dest: 'dist',
         moduleName: 'stampit'
       }
@@ -70,7 +72,7 @@ function execute() {
       {
         format: 'cjs',
         ext: '.js',
-        babelPlugins: es2015Plugins,
+        babelPresets: es2015Presets,
         dest: '.',
         moduleName: 'compose'
       }
@@ -80,7 +82,7 @@ function execute() {
       {
         format: 'cjs',
         ext: '.js',
-        babelPlugins: es2015Plugins,
+        babelPresets: es2015Presets,
         dest: '.',
         moduleName: 'isStamp'
       }
@@ -90,7 +92,7 @@ function execute() {
       {
         format: 'cjs',
         ext: '.js',
-        babelPlugins: es2015Plugins,
+        babelPresets: es2015Presets,
         dest: '.',
         moduleName: 'isComposable'
       }
@@ -137,6 +139,7 @@ function makeBundle(config) {
         babelrc: false,
         exclude: 'node_modules/**',
         plugins: config.babelPlugins || [],
+        presets: config.babelPresets || [],
         runtimeHelpers: isUMD,
         externalHelpers: isUMD
       })

--- a/package.json
+++ b/package.json
@@ -27,26 +27,6 @@
   "dependencies": {},
   "devDependencies": {
     "babel-cli": "^6.10.1",
-    "babel-plugin-check-es2015-constants": "^6.8.0",
-    "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
-    "babel-plugin-transform-es2015-block-scoped-functions": "^6.8.0",
-    "babel-plugin-transform-es2015-block-scoping": "^6.15.0",
-    "babel-plugin-transform-es2015-classes": "^6.14.0",
-    "babel-plugin-transform-es2015-computed-properties": "^6.8.0",
-    "babel-plugin-transform-es2015-destructuring": "^6.9.0",
-    "babel-plugin-transform-es2015-duplicate-keys": "^6.8.0",
-    "babel-plugin-transform-es2015-for-of": "^6.8.0",
-    "babel-plugin-transform-es2015-function-name": "^6.9.0",
-    "babel-plugin-transform-es2015-literals": "^6.8.0",
-    "babel-plugin-transform-es2015-object-super": "^6.8.0",
-    "babel-plugin-transform-es2015-parameters": "^6.9.0",
-    "babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",
-    "babel-plugin-transform-es2015-spread": "^6.8.0",
-    "babel-plugin-transform-es2015-sticky-regex": "^6.8.0",
-    "babel-plugin-transform-es2015-template-literals": "^6.8.0",
-    "babel-plugin-transform-es2015-typeof-symbol": "^6.8.0",
-    "babel-plugin-transform-es2015-unicode-regex": "^6.8.0",
-    "babel-plugin-transform-regenerator": "^6.14.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-runtime": "^6.9.2",
     "check-compose": "^3.2.0",
@@ -96,34 +76,5 @@
         "stampit.full.min.js"
       ]
     }
-  ],
-  "babel": {
-    "plugins": [
-      ["babel-plugin-transform-es2015-template-literals", {"loose": true}],
-      "babel-plugin-transform-es2015-literals",
-      "babel-plugin-transform-es2015-function-name",
-      "babel-plugin-transform-es2015-arrow-functions",
-      "babel-plugin-transform-es2015-block-scoped-functions",
-      ["babel-plugin-transform-es2015-classes", {"loose": true}],
-      "babel-plugin-transform-es2015-object-super",
-      "babel-plugin-transform-es2015-shorthand-properties",
-      "babel-plugin-transform-es2015-duplicate-keys",
-      ["babel-plugin-transform-es2015-computed-properties", {"loose": true}],
-      ["babel-plugin-transform-es2015-for-of", {"loose": true}],
-      "babel-plugin-transform-es2015-sticky-regex",
-      "babel-plugin-transform-es2015-unicode-regex",
-      "babel-plugin-check-es2015-constants",
-      ["babel-plugin-transform-es2015-spread", {"loose": true}],
-      "babel-plugin-transform-es2015-parameters",
-      ["babel-plugin-transform-es2015-destructuring", {"loose": true}],
-      "babel-plugin-transform-es2015-block-scoping",
-      [
-        "babel-plugin-transform-regenerator",
-        {
-          "async": false,
-          "asyncGenerators": false
-        }
-      ]
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
React-native-packager try to use babel config in package.json or .babelrc and throw "Unknown plugin" error.
This PR will solve this issue and allow using stampit with react-native.

https://github.com/facebook/react-native/issues/4062
[react-native TransformError when requiring a node_module that has a package.json with a babel config that specifies uninstalled plugin (stackoverflow)](http://stackoverflow.com/questions/37521478/react-native-transformerror-when-requiring-a-node-module-that-has-a-package-json)
