### PR TITLE
Implement `composers` feature

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -310,7 +310,7 @@ const stamp = stampit().compose(ComponentsMonitoring)
   .methods({foo() {}})
   .props({a: 1});
 
-console.log(stamp.compose._wasComposedOf);
+console.log(stamp.compose.configuration._wasComposedOf);
 ```
 
 **NOTE:** The example below can be implemented using plain old higher order functions.
@@ -344,7 +344,7 @@ const stamp = stampit().compose(ProduceFunction, ComponentsMonitoring)
     console.log('A clone of this function was returned as a stamp result');
   });
 
-console.log(stamp.compose._wasComposedOf);
+console.log(stamp.compose.configuration._wasComposedOf);
 const producedFunction = stamp();
 producedFunction(); // prints "A clone of this function was returned as a stamp result"
 ```

--- a/src/extract-functions.js
+++ b/src/extract-functions.js
@@ -1,7 +1,0 @@
-import isFunction from './isFunction';
-
-const concat = Array.prototype.concat;
-export default function () {
-  const fns = concat.apply([], arguments).filter(isFunction);
-  return fns.length === 0 ? undefined : fns;
-}

--- a/src/isComposable.js
+++ b/src/isComposable.js
@@ -1,3 +1,3 @@
-import isObject from './isObject';
+import {isObject} from './utils';
 
 export default isObject;

--- a/src/isFunction.js
+++ b/src/isFunction.js
@@ -1,3 +1,0 @@
-export default function isFunction(obj) {
-  return typeof obj === 'function';
-}

--- a/src/isObject.js
+++ b/src/isObject.js
@@ -1,4 +1,0 @@
-export default function isObject(obj) {
-  const type = typeof obj;
-  return !!obj && (type === 'object' || type === 'function');
-}

--- a/src/isPlainObject.js
+++ b/src/isPlainObject.js
@@ -1,4 +1,0 @@
-export default function isPlainObject(value) {
-  return !!value && typeof value === 'object' &&
-    Object.getPrototypeOf(value) === Object.prototype;
-}

--- a/src/isStamp.js
+++ b/src/isStamp.js
@@ -1,4 +1,4 @@
-import isFunction from './isFunction';
+import {isFunction} from './utils';
 
 /**
  * Returns true if argument is a stamp.

--- a/src/merge.js
+++ b/src/merge.js
@@ -1,5 +1,4 @@
-import isObject from './isObject';
-import isPlainObject from './isPlainObject';
+import {isArray, isObject, isPlainObject} from './utils';
 
 /**
  * The 'src' argument plays the command role.
@@ -13,7 +12,7 @@ function mergeOne(dst, src) {
 
   // According to specification arrays must be concatenated.
   // Also, the '.concat' creates a new array instance. Overrides the 'dst'.
-  if (Array.isArray(src)) return (Array.isArray(dst) ? dst : []).concat(src);
+  if (isArray(src)) return (isArray(dst) ? dst : []).concat(src);
 
   // Now deal with non plain 'src' object. 'src' overrides 'dst'
   // Note that functions are also assigned! We do not deep merge functions.
@@ -31,7 +30,7 @@ function mergeOne(dst, src) {
     if (srcValue !== undefined) {
       const dstValue = returnValue[key];
       // Recursive calls to mergeOne() must allow only plain objects or arrays in dst
-      const newDst = isPlainObject(dstValue) || Array.isArray(srcValue) ? dstValue : {};
+      const newDst = isPlainObject(dstValue) || isArray(srcValue) ? dstValue : {};
 
       // deep merge each property. Recursion!
       returnValue[key] = mergeOne(newDst, srcValue);

--- a/src/stampit.js
+++ b/src/stampit.js
@@ -118,7 +118,7 @@ function stampit(...args) {
     for (let i = 0; i < composerFunctions.length; i += 1) {
       if (isFunction(composerFunctions[i])) {
         const returnedValue = composerFunctions[i]({stamp, composables});
-        stamp = returnedValue === undefined ? stamp : returnedValue;
+        stamp = isStamp(returnedValue) ? returnedValue : stamp;
       }
     }
   }

--- a/src/stampit.js
+++ b/src/stampit.js
@@ -8,7 +8,7 @@ import isStamp from './isStamp';
 function createUtilityFunction(propName, action) {
   return function composeUtil() {
     return ((this && this.compose) || stampit).call(this, {
-      [`${propName}`]: action({}, ...arguments)
+      [propName]: action({}, ...arguments)
     });
   };
 }

--- a/src/standardise-descriptor.js
+++ b/src/standardise-descriptor.js
@@ -34,6 +34,8 @@ export default function ({
   initializers,
   init,
 
+  composers,
+
   deepProperties,
   deepProps,
 
@@ -51,9 +53,7 @@ export default function ({
   conf,
 
   deepConfiguration,
-  deepConf,
-
-  composers
+  deepConf
 } = {}) {
   const p = isObject(props) || isObject(refs) || isObject(properties) ?
     assign({}, props, refs, properties) : undefined;

--- a/src/standardise-descriptor.js
+++ b/src/standardise-descriptor.js
@@ -1,8 +1,5 @@
-import isObject from './isObject';
-import extractFunctions from './extract-functions';
+import {assign, isObject, extractFunctions, concatAssignFunctions} from './utils';
 import merge from './merge';
-
-const assign = Object.assign;
 
 /**
  * Converts stampit extended descriptor to a standard one.
@@ -24,6 +21,7 @@ const assign = Object.assign;
  * @param [conf]
  * @param [deepConfiguration]
  * @param [deepConf]
+ * @param [composers]
  * @returns {Descriptor}
  */
 export default function ({
@@ -53,7 +51,9 @@ export default function ({
   conf,
 
   deepConfiguration,
-  deepConf
+  deepConf,
+
+  composers
 } = {}) {
   const p = isObject(props) || isObject(refs) || isObject(properties) ?
     assign({}, props, refs, properties) : undefined;
@@ -73,16 +73,26 @@ export default function ({
   let dc = isObject(deepConf) ? merge({}, deepConf) : undefined;
   dc = isObject(deepConfiguration) ? merge(dc, deepConfiguration) : dc;
 
-  return {
-    methods,
-    properties: p,
-    initializers: extractFunctions(init, initializers),
-    deepProperties: dp,
-    staticProperties: sp,
-    staticDeepProperties: dsp,
-    propertyDescriptors,
-    staticPropertyDescriptors,
-    configuration: c,
-    deepConfiguration: dc
-  };
+  const ii = extractFunctions(init, initializers);
+
+  const composerFunctions = extractFunctions(composers);
+  if (composerFunctions) {
+    dc = dc || {};
+    concatAssignFunctions(dc, composerFunctions, 'composers');
+  }
+
+  const descriptor = {};
+  if (methods) descriptor.methods = methods;
+  if (p) descriptor.properties = p;
+  if (ii) descriptor.initializers = ii;
+  if (dp) descriptor.deepProperties = dp;
+  if (sp) descriptor.staticProperties = sp;
+  if (methods) descriptor.methods = methods;
+  if (dsp) descriptor.staticDeepProperties = dsp;
+  if (propertyDescriptors) descriptor.propertyDescriptors = propertyDescriptors;
+  if (staticPropertyDescriptors) descriptor.staticPropertyDescriptors = staticPropertyDescriptors;
+  if (c) descriptor.configuration = c;
+  if (dc) descriptor.deepConfiguration = dc;
+
+  return descriptor;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,53 @@
+import merge from './merge';
+
+export const assign = Object.assign;
+export const isArray = Array.isArray;
+
+export function isFunction(obj) {
+  return typeof obj === 'function';
+}
+
+export function isObject(obj) {
+  const type = typeof obj;
+  return !!obj && (type === 'object' || type === 'function');
+}
+
+export function isPlainObject(value) {
+  return !!value && typeof value === 'object' &&
+    Object.getPrototypeOf(value) === Object.prototype;
+}
+
+
+const concat = Array.prototype.concat;
+export function extractFunctions() {
+  const fns = concat.apply([], arguments).filter(isFunction);
+  return fns.length === 0 ? undefined : fns;
+}
+
+export function concatAssignFunctions(dstObject, srcArray, propName) {
+  if (isArray(srcArray)) {
+    const length = srcArray.length;
+    dstObject[propName] = dstObject[propName] || [];
+    const dstArray = dstObject[propName];
+    for (let i = 0; i < length; i += 1) {
+      const fn = srcArray[i];
+      if (isFunction(fn) && dstArray.indexOf(fn) < 0) {
+        dstArray.push(fn);
+      }
+    }
+  }
+}
+
+
+function combineProperties(dstObject, srcObject, propName, action) {
+  if (!isObject(srcObject[propName])) return;
+  if (!isObject(dstObject[propName])) dstObject[propName] = {};
+  action(dstObject[propName], srcObject[propName]);
+}
+
+export function deepMergeAssign(dstObject, srcObject, propName) {
+  combineProperties(dstObject, srcObject, propName, merge);
+}
+export function mergeAssign(dstObject, srcObject, propName) {
+  combineProperties(dstObject, srcObject, propName, assign);
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,15 +25,15 @@ export function extractFunctions() {
 }
 
 export function concatAssignFunctions(dstObject, srcArray, propName) {
-  if (isArray(srcArray)) {
-    const length = srcArray.length;
-    dstObject[propName] = dstObject[propName] || [];
-    const dstArray = dstObject[propName];
-    for (let i = 0; i < length; i += 1) {
-      const fn = srcArray[i];
-      if (isFunction(fn) && dstArray.indexOf(fn) < 0) {
-        dstArray.push(fn);
-      }
+  if (!isArray(srcArray)) return;
+
+  const length = srcArray.length;
+  const dstArray = dstObject[propName] || [];
+  dstObject[propName] = dstArray;
+  for (let i = 0; i < length; i += 1) {
+    const fn = srcArray[i];
+    if (isFunction(fn) && dstArray.indexOf(fn) < 0) {
+      dstArray.push(fn);
     }
   }
 }

--- a/test/composers.js
+++ b/test/composers.js
@@ -6,12 +6,11 @@ import stampit from '../src/stampit';
 
 test('stampit({ composers() })', (t) => {
   let executed = 0;
-  let passedStamp = null;
+  let passedStamp;
   const stamp = stampit({
     composers() {
       t.equal(arguments.length, 1, 'have single argument');
       t.ok(_.isPlainObject(arguments[0]), 'argument is an object');
-      passedStamp = arguments[0].stamp;
       t.ok(_.isArray(arguments[0].composables), 'composables passed');
       t.equal(arguments[0].composables.length, 1, 'only one composable passed');
       t.ok(_.isPlainObject(arguments[0].composables[0]), 'the composable is a descriptor');
@@ -20,6 +19,7 @@ test('stampit({ composers() })', (t) => {
       t.ok(_.isArray(arguments[0].composables[0].deepConfiguration.composers),
         'first composable have the composers list');
       executed += 1;
+      passedStamp = arguments[0].stamp;
     }
   });
 
@@ -88,3 +88,46 @@ test('stampit({ composers() }).compose({ composers() })', (t) => {
   t.end();
 });
 
+test('stampit({ composers() }) returned value replaces stamp', (t) => {
+  const replacement = stampit();
+  const stamp = stampit({
+    composers() {
+      return replacement;
+    }
+  });
+
+  t.equal(stamp, replacement, 'composer returned value should replace original stamp');
+
+  t.end();
+});
+
+test('stampit({ composers() }) a non-stamp should be ignored', (t) => {
+  const replacement = stampit();
+  const stamp = stampit({
+    composers() {
+      return () => {}; // non-stamp
+    }
+  });
+
+  t.notEqual(stamp, replacement, 'composer returned value should not replace original stamp');
+
+  t.end();
+});
+
+test('stampit({ composers() }) returned value passed to the second composer', (t) => {
+  const replacement = stampit();
+  let stamp2;
+  stampit({
+    composers() {
+      return replacement;
+    }
+  }, {
+    composers() {
+      stamp2 = replacement;
+    }
+  });
+
+  t.equal(stamp2, replacement, 'second composer should get first composer return value');
+
+  t.end();
+});

--- a/test/composers.js
+++ b/test/composers.js
@@ -1,0 +1,90 @@
+import test from 'tape';
+import _ from 'lodash';
+import stampit from '../src/stampit';
+
+// composers
+
+test('stampit({ composers() })', (t) => {
+  let executed = 0;
+  let passedStamp = null;
+  const stamp = stampit({
+    composers() {
+      t.equal(arguments.length, 1, 'have single argument');
+      t.ok(_.isPlainObject(arguments[0]), 'argument is an object');
+      passedStamp = arguments[0].stamp;
+      t.ok(_.isArray(arguments[0].composables), 'composables passed');
+      t.equal(arguments[0].composables.length, 1, 'only one composable passed');
+      t.ok(_.isPlainObject(arguments[0].composables[0]), 'the composable is a descriptor');
+      t.ok(_.isPlainObject(arguments[0].composables[0].deepConfiguration),
+        'composable was converted to standard descriptor');
+      t.ok(_.isArray(arguments[0].composables[0].deepConfiguration.composers),
+        'first composable have the composers list');
+      executed += 1;
+    }
+  });
+
+  t.ok(stamp.compose.deepConfiguration,
+    'should add deepConfiguration');
+  t.ok(stamp.compose.deepConfiguration.composers,
+    'should add deepConfiguratuin.composers');
+  t.equal(stamp.compose.deepConfiguration.composers.length, 1,
+    'should be single composer');
+  t.equal(executed, 1,
+    'should be executed while composing');
+  t.equal(passedStamp, stamp, 'stamp passed');
+
+  t.end();
+});
+
+test('stampit({ composers: function[] })', (t) => {
+  let executed1 = 0;
+  let executed2 = 0;
+  let stamp1;
+  let stamp2;
+  const actualStamp = stampit({
+    composers: [
+      function composer1({stamp}) {
+        stamp1 = stamp;
+        executed1 += 1;
+      },
+      function composer2({stamp}) {
+        stamp2 = stamp;
+        executed2 += 1;
+      }
+    ]
+  });
+
+  t.equal(stamp1, actualStamp, 'stamp passed to first composer');
+  t.equal(stamp2, actualStamp, 'stamp passed to second composer');
+  t.equal(executed1, 1, 'first composer executed');
+  t.equal(executed2, 1, 'second composer executed');
+
+  t.end();
+});
+
+test('stampit({ composers() }).compose({ composers() })', (t) => {
+  let executed1 = 0;
+  let executed2 = 0;
+  let stamp1;
+  let stamp2;
+  const actualStamp = stampit({
+    composers({stamp}) {
+      stamp1 = stamp;
+      executed1 += 1;
+    }
+  })
+    .compose({
+      composers({stamp}) {
+        stamp2 = stamp;
+        executed2 += 1;
+      }
+    });
+
+  t.equal(stamp1, actualStamp, 'stamp passed to first composer');
+  t.equal(stamp2, actualStamp, 'stamp passed to second composer');
+  t.equal(executed1, 2, 'first composer executed twice');
+  t.equal(executed2, 1, 'second composer executed');
+
+  t.end();
+});
+

--- a/test/stampit-shortcuts.js
+++ b/test/stampit-shortcuts.js
@@ -25,9 +25,19 @@ test('stampit.refs shortcut', (t) => {
 });
 
 test('stampit.init shortcut', (t) => {
-  const init = {method1() {}};
+  const init = () => {};
   const stamp1 = stampit({init: init});
   const stamp2 = stampit.init(init);
+
+  t.deepEqual(_.toPlainObject(stamp1.compose), _.toPlainObject(stamp2.compose));
+
+  t.end();
+});
+
+test('stampit.composers shortcut', (t) => {
+  const composer = () => {};
+  const stamp1 = stampit({composers: composer});
+  const stamp2 = stampit.composers(composer);
 
   t.deepEqual(_.toPlainObject(stamp1.compose), _.toPlainObject(stamp2.compose));
 
@@ -93,7 +103,8 @@ test('all shortcuts combined', (t) => {
     .staticProperties().staticDeepProperties()
     .configuration().deepConfiguration()
     .propertyDescriptors().staticPropertyDescriptors()
-    .refs().props().init().deepProps().statics().deepStatics().conf().deepConf();
+    .refs().props().init().composers().deepProps()
+    .statics().deepStatics().conf().deepConf();
 
   const PrintFoo = methods({
     printFoo() {
@@ -103,7 +114,8 @@ test('all shortcuts combined', (t) => {
     .staticProperties().staticDeepProperties()
     .configuration().deepConfiguration()
     .propertyDescriptors().staticPropertyDescriptors()
-    .refs().props().init().deepProps().statics().deepStatics().conf().deepConf();
+    .refs().props().init().composers().deepProps()
+    .statics().deepStatics().conf().deepConf();
 
   const Init = init(function ({foo}) {
     this.foo = foo;
@@ -111,7 +123,8 @@ test('all shortcuts combined', (t) => {
     .staticProperties().staticDeepProperties()
     .configuration().deepConfiguration()
     .propertyDescriptors().staticPropertyDescriptors()
-    .refs().props().init().deepProps().statics().deepStatics().conf().deepConf();
+    .refs().props().init().composers().deepProps()
+    .statics().deepStatics().conf().deepConf();
 
   const Foo = compose(HasFoo, PrintFoo, Init);
 


### PR DESCRIPTION
- Implement `composers` feature in a specs compatible way.
- Move all internal function to the utils.js for simplicity.
- Performance optimize object creation (create less closure objects)
- Performance optimize composition (create less closure objects)