### PR TITLE
Rollup did not handle tree-shaking properly and exported everything

### DIFF
--- a/src/is-function.js
+++ b/src/is-function.js
@@ -1,0 +1,3 @@
+export default function isFunction(obj) {
+  return typeof obj === 'function';
+}

--- a/src/is-object.js
+++ b/src/is-object.js
@@ -1,0 +1,4 @@
+export default function isObject(obj) {
+  const type = typeof obj;
+  return !!obj && (type === 'object' || type === 'function');
+}

--- a/src/isComposable.js
+++ b/src/isComposable.js
@@ -1,3 +1,3 @@
-import {isObject} from './utils';
+import isObject from './is-object';
 
 export default isObject;

--- a/src/isStamp.js
+++ b/src/isStamp.js
@@ -1,4 +1,4 @@
-import {isFunction} from './utils';
+import isFunction from './is-function';
 
 /**
  * Returns true if argument is a stamp.

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,16 +1,12 @@
 import merge from './merge';
+import isFunction from './is-function';
+import isObject from './is-object';
+
+export {isFunction};
+export {isObject};
 
 export const assign = Object.assign;
 export const isArray = Array.isArray;
-
-export function isFunction(obj) {
-  return typeof obj === 'function';
-}
-
-export function isObject(obj) {
-  const type = typeof obj;
-  return !!obj && (type === 'object' || type === 'function');
-}
 
 export function isPlainObject(value) {
   return !!value && typeof value === 'object' &&


### PR DESCRIPTION
Rollup did not handle tree-shaking properly and exported everything to isStamp/isCompose functions. The files were huge instead of being small.