### PR TITLE
Composers fixes

### DIFF
--- a/src/stampit.js
+++ b/src/stampit.js
@@ -106,7 +106,6 @@ const baseStampit = compose(
  * @return {Stamp}
  */
 function stampit(...args) {
-  if (isStamp(this)) args.unshift(this);
   const composables = args.filter(isComposable)
     .map(arg => isStamp(arg) ? arg : standardiseDescriptor(arg));
 
@@ -125,6 +124,7 @@ function stampit(...args) {
     }
     stamp.compose.deepConfiguration.composers = uniqueComposers;
 
+    if (isStamp(this)) composables.unshift(this);
     for (let i = 0; i < uniqueComposers.length; i += 1) {
       const composer = uniqueComposers[i];
       const returnedValue = composer({stamp, composables});

--- a/test/composers.js
+++ b/test/composers.js
@@ -131,3 +131,38 @@ test('stampit({ composers() }) returned value passed to the second composer', (t
 
   t.end();
 });
+
+test('composers should be deduped', (t) => {
+  const stamp2 = stampit();
+  const stamp = stampit({composers() {}});
+
+  const result = stamp.compose(stamp2).compose({}).compose(stamp);
+  const composers = result.compose.deepConfiguration.composers;
+  t.equal(composers.length, 1, 'should dedupe composers');
+
+  t.end();
+});
+
+test('stamp.compose({ composers() }) passes full composables array', (t) => {
+  let run = 0;
+  const stamp2 = stampit();
+  const stamp = stampit({
+    composers({composables}) {
+      run += 1;
+      if (run === 1) {
+        t.equal(composables.length, 1, 'creating stamp should pass one composable');
+      }
+      if (run === 2) {
+        t.equal(composables.length, 2, 'inheriting stamp should pass one composable');
+        t.equal(composables[0], stamp, 'first composable must be stamp itself');
+        t.equal(composables[1], stamp2, 'second composable must be passed');
+      }
+    }
+  });
+
+  stamp.compose(stamp2);
+
+  t.equal(run, 2, 'should invoke composer twice');
+
+  t.end();
+});


### PR DESCRIPTION
Fixes:
* Composers array should have been deduplicated from the beginning. Not it is.
* The main stamp was missing in the `composables` argument when `stamp.compose()` syntax was used.