### PR TITLE
Use a ponyfill instead of using Object.assign directly, to support IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "type": "git",
     "url": "git@github.com:stampit-org/stampit.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "object-assign": "^4.1.1"
+  },
   "devDependencies": {
     "babel-cli": "^6.10.1",
     "babel-preset-es2015": "^6.16.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+import objectAssign from 'object-assign';
 import merge from './merge';
 import isFunction from './is-function';
 import isObject from './is-object';
@@ -5,7 +6,7 @@ import isObject from './is-object';
 export {isFunction};
 export {isObject};
 
-export const assign = Object.assign;
+export const assign = objectAssign;
 export const isArray = Array.isArray;
 
 export function isPlainObject(value) {


### PR DESCRIPTION
Fixes https://github.com/stampit-org/stampit/issues/319