### PR TITLE
IE11 and node.js 0.10 support by adding 100 more bytes to the bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,15 @@ $ bower install stampit
 or
 $ bower install stampit=https://npmcdn.com/stampit@3/dist/stampit.umd.min.js
 or
-$ bower install stampit=https://unpkg.com/stampit@3.1.2/dist/stampit.umd.js
+$ bower install stampit=https://unpkg.com/stampit@3.1.3/dist/stampit.umd.js
 ```
 
 Browsers: [![CDNJS](https://img.shields.io/cdnjs/v/stampit.svg)](https://cdnjs.com/libraries/stampit)
 [![UNPKG](https://img.shields.io/badge/unpkg.com--green.svg)](https://unpkg.com/stampit@latest/dist/stampit.umd.min.js)
 
-**WARNING!** If running in node.js <= v0.12 or IE <= 11 then you'd need to polyfill the `Object.assign`. Like [this](https://github.com/sindresorhus/object-assign), or [that](https://github.com/Financial-Times/polyfill-service/blob/master/polyfills/Object/assign/polyfill.js) ([autodetected](https://cdn.polyfill.io/v2/polyfill.min.js?features=Object.assign)). [More information](https://github.com/stampit-org/stampit/pull/320#issuecomment-325402058).
+## Compatibility
+
+Be ware. Stampit should run fine in any ES5 browser or any node.js. But we test only against node.js v4 and above. 
 
 ## API
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,7 +5,19 @@ import isObject from './is-object';
 export {isFunction};
 export {isObject};
 
-export const assign = Object.assign;
+export const assign = Object.assign || function assign(to) {
+  const args = arguments;
+  for (let s = 1; s < args.length; s += 1) {
+    const from = args[s];
+
+    for (const key in Object.keys(from)) { // eslint-disable-line
+      to[key] = from[key];
+    }
+  }
+
+  return to;
+};
+
 export const isArray = Array.isArray;
 
 export function isPlainObject(value) {


### PR DESCRIPTION
This removes the burden many people have. They don't need to polyfil anything now. With this PR Stampit core feature - **dependencelessness** (What a word!) is preserved. The resulting minified bundle increases by 100 bytes, the .min.gz bundle increases by 40 bytes. :)