### PR TITLE
Add `stampit.version`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,3 +197,9 @@ npm run browsertest
 To run tests in a different browser:
 * Open the `./test/index.html` in your browser, and
 * open developer's console. The logs should indicate success.
+
+### Publishing to NPM registry
+```bash
+npx cut-release
+```
+It will run the `cut-release` utility which would ask you if you're publishing patch, minor, or major version. Then it will execute `npm version`, `git push` and `npm publish` with proper arguments for you.

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "check": "npm run audit && npm run deps",
     "watch": "watch 'clear && npm -s test' test/ src/",
     "minify": "mkdirp ./dist/ && uglifyjs src/stampit.js -c collapse_vars,evaluate=false,screw_ie8,unsafe,loops=false,keep_fargs=false,pure_getters,unused,dead_code,keep_fnames=[\"'stampit','Stamp'\"] -m --reserved stampit,Stamp -o dist/stampit.min.js",
+    "postversion": "V=`node -e \"process.stdout.write(require('./package.json').version)\"` && sed s/VERSION/$V/g dist/stampit.min.js > dist/tmp && rm dist/stampit.min.js && mv dist/tmp dist/stampit.min.js",
     "postminify": "ls -l dist/ && echo GZIP size: && gzip-size --raw dist/stampit.min.js"
   },
   "license": "MIT",

--- a/src/stampit.js
+++ b/src/stampit.js
@@ -409,6 +409,7 @@
   baseStampit = compose(var4);
 
   var2[_compose] = var2.bind(); // bind to undefined
+  var2.version = 'VERSION';
 
   if (typeof _undefined != typeof module) module.exports = var2; else self.stampit = var2;
 }();


### PR DESCRIPTION
After that all the stampit distros will have `stampit.version === "4.1.0"` property.