### PR TITLE
[WIP] typescript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://stampit.js.org",
   "main": "dist/stampit.min.js",
   "minified:main": "dist/stampit.min.js",
-  "typings": "./src/stampit.d.ts",
+  "types": "./types/index.d.ts",
   "keywords": [
     "object",
     "prototype",
@@ -38,6 +38,7 @@
     "nyc": "^14.1.1",
     "require-all": "^2.2.0",
     "tape": "^4.2.2",
+    "typescript": "^3.6.3",
     "uglify-js": "^2.8.29"
   },
   "scripts": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,7 +18,7 @@ declare namespace stampit {
     // TODO: Add description
     const version: string;
     /** The stamp Descriptor */
-    interface Descriptor<I, F extends Specification.Factory<any> = Specification.Factory<I>> extends Specification.Descriptor<I, F> {
+    interface Descriptor<I, F extends Specification.Stamp<any> = Specification.Stamp<I>> extends Specification.Descriptor<I, F> {
         /** Create a new stamp based on this descriptor */
         // ? is this function signature trully needed?
         (...composables: Array<StampitComposable<I>>): Stamp<I>;
@@ -30,7 +30,7 @@ declare namespace stampit {
 
     // TODO: Add description
     // ? shouldn't stampit.Option be stampit.(Extended)Descriptor really?
-    interface Options<I, F extends Specification.Factory<any> = Specification.Factory<I>> extends Omit<Specification.Descriptor<I, F>, 'initializers'> {
+    interface Options<I, F extends Specification.Stamp<any> = Specification.Stamp<I>> extends Omit<Specification.Descriptor<I, F>, 'initializers'> {
         /** Properties which will shallowly copied into any future created instance. */
         props?: Specification.PropertyMap;
         /** Deeply merged properties of object instances */
@@ -59,7 +59,7 @@ declare namespace stampit {
      * A factory function that will produce new objects using the
      * prototypes that are passed in or composed.
      */
-    interface Stamp<I = any, F extends Specification.Factory<any> = Specification.Factory<I>> extends Specification.Factory<I> {
+    interface Stamp<I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>> extends Specification.Stamp<I> {
         /**
          * Just like calling stamp(), stamp.create() invokes the stamp and returns a new instance.
          * @param state Properties you wish to set on the new objects.
@@ -312,7 +312,7 @@ declare namespace stampit {
      * @return A new Stamp.
      */
     function staticProperties
-        <I = any, F extends Specification.Factory<any> = Specification.Factory<I>>
+        <I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>>
         (...statics: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
 
     /**
@@ -321,7 +321,7 @@ declare namespace stampit {
      * @return A new Stamp.
      */
     function staticProperties
-        <I = any, F extends Specification.Factory<any> = Specification.Factory<I>>
+        <I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>>
         (...statics: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
 
     /**
@@ -330,7 +330,7 @@ declare namespace stampit {
      * @returns A new stamp
      */
     function deepStatics
-        <I = any, F extends Specification.Factory<any> = Specification.Factory<I>>
+        <I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>>
         (...deepStatics: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
 
     /**
@@ -339,7 +339,7 @@ declare namespace stampit {
      * @returns A new stamp
      */
     function staticDeepProperties
-        <I = any, F extends Specification.Factory<any> = Specification.Factory<I>>
+        <I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>>
         (...deepStatics: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
 
     /**
@@ -348,7 +348,7 @@ declare namespace stampit {
      * @returns A new Stamp
      */
     function conf
-        <I = any, F extends Specification.Factory<any> = Specification.Factory<I>>
+        <I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>>
         (...deepConfs: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
 
     /**
@@ -357,7 +357,7 @@ declare namespace stampit {
      * @returns A new Stamp
      */
     function configuration
-        <I = any, F extends Specification.Factory<any> = Specification.Factory<I>>
+        <I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>>
         (...deepConfs: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
 
     /**
@@ -366,7 +366,7 @@ declare namespace stampit {
      * @returns A new Stamp
      */
     function deepConf
-        <I = any, F extends Specification.Factory<any> = Specification.Factory<I>>
+        <I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>>
         (...deepConfs: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
 
     /**
@@ -375,7 +375,7 @@ declare namespace stampit {
      * @returns A new Stamp
      */
     function deepConfiguration
-        <I = any, F extends Specification.Factory<any> = Specification.Factory<I>>
+        <I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>>
         (...deepConfs: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
 
     /**
@@ -393,7 +393,7 @@ declare namespace stampit {
      * @returns A new Stamp
      */
     function staticPropertyDescriptors
-        <I = any, F extends Specification.Factory<any> = Specification.Factory<I>>
+        <I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>>
         (...descriptors: Array<PropertyDescriptorMap> & ThisType<F>): Stamp<I>;
 
     /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,25 +12,32 @@
  * @param options Stampit options object containing methods,
  * init, props, statics, configurations, and property descriptors.
  */
-declare function stampit<I = any>(...composables: Array<stampit.StampitComposable<I>>): stampit.Stamp<I>;
+declare function stampit<I = any>(...composables: Array<stampit.Composable<I>>): stampit.Stamp<I>;
 
 declare namespace stampit {
-    // TODO: Add description
-    const version: string;
-    /** The stamp Descriptor */
-    interface Descriptor<I, F extends Specification.Stamp<any> = Specification.Stamp<I>> extends Specification.Descriptor<I, F> {
-        /** Create a new stamp based on this descriptor */
-        // ? is this function signature trully needed?
-        (...composables: Array<StampitComposable<I>>): Stamp<I>;
-    }
+    /**
+     * Extract the type of the object defined by `Stamp`, `Descriptor` (or `POJO`) types.
+     * @param {type} I Type definition to extract the object type from.
+     * @returns {type} The object type.
+     */
+    type StampType<I> = I extends Stamp<infer I> ? I
+                      : I extends Descriptor<infer I> ? I
+                      : I extends Specification.POJO ? I
+                      : never;
 
     /** Any composable object (stamp or descriptor) */
-    // ! should have been StampitComposable
-    // type Composable<I> = Stamp<I> | Descriptor<I>;
+    /** Stampit Composable for main stampit() function */
+    type Composable<I, U = StampType<I>> = Stamp<U> | Descriptor<U>;
 
-    // TODO: Add description
-    // ? shouldn't stampit.Option be stampit.(Extended)Descriptor really?
-    interface Options<I, F extends Specification.Stamp<any> = Specification.Stamp<I>> extends Omit<Specification.Descriptor<I, F>, 'initializers'> {
+    /** Version of the NPM `stampit` package */
+    const version: string;
+
+    /** The `stampit` Descriptor */
+    interface Descriptor<I, F extends Specification.Stamp<any> = Specification.Stamp<I>> extends Omit<Specification.Descriptor<I, F>, 'initializers'> {
+        /** Create a new stamp based on this descriptor */
+        // ? is this function signature trully needed?
+        // (...composables: Array<Composable<I>>): Stamp<I>;
+
         /** Properties which will shallowly copied into any future created instance. */
         props?: Specification.PropertyMap;
         /** Deeply merged properties of object instances */
@@ -51,15 +58,11 @@ declare namespace stampit {
         name: string;
     }
 
-    /** Stampit Composable for main stampit() function */
-    // TODO: simplify after factorizing interfaces
-    type StampitComposable<I, U = Specification.StampType<I>> = Specification.Composable<I, U> | Stamp<I> | Descriptor<U> | Options<U>;
-
     /**
      * A factory function that will produce new objects using the
      * prototypes that are passed in or composed.
      */
-    interface Stamp<I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>> extends Specification.Stamp<I> {
+    interface Stamp<I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>> extends Omit<Specification.Stamp<I>, 'compose'> {
         /**
          * Just like calling stamp(), stamp.create() invokes the stamp and returns a new instance.
          * @param state Properties you wish to set on the new objects.
@@ -82,7 +85,7 @@ declare namespace stampit {
          * @param methods Object(s) containing map of method names and bodies for delegation.
          * @return A new Stamp.
          */
-        methods(...methods: Array<{}>): Stamp<I>;
+        methods(...methods: Array<Specification.MethodMap>): Stamp<I>;
 
         /**
          * Take a variable number of objects and shallow assign them to any future
@@ -90,7 +93,7 @@ declare namespace stampit {
          * @param objects Object(s) to shallow assign for each new object.
          * @return A new Stamp.
          */
-        props(...objects: Array<{}>): Stamp<I>;
+        props(...objects: Array<Specification.PropertyMap>): Stamp<I>;
 
         /**
          * Take a variable number of objects and shallow assign them to any future
@@ -98,7 +101,7 @@ declare namespace stampit {
          * @param objects Object(s) to shallow assign for each new object.
          * @return A new Stamp.
          */
-        properties(...objects: Array<{}>): Stamp<I>;
+        properties(...objects: Array<Specification.PropertyMap>): Stamp<I>;
 
         /**
          * Take a variable number of objects and deeply merge them to any future
@@ -107,7 +110,7 @@ declare namespace stampit {
          * @param deepObjects The object(s) to deeply merge for each new object
          * @returns A new Stamp
          */
-        deepProps(...deepObjects: Array<{}>): Stamp<I>;
+        deepProps(...deepObjects: Array<Specification.PropertyMap>): Stamp<I>;
 
         /**
          * Take a variable number of objects and deeply merge them to any future
@@ -116,7 +119,7 @@ declare namespace stampit {
          * @param deepObjects The object(s) to deeply merge for each new object
          * @returns A new Stamp
          */
-        deepProperties(...deepObjects: Array<{}>): Stamp<I>;
+        deepProperties(...deepObjects: Array<Specification.PropertyMap>): Stamp<I>;
 
         /**
          * Take in a variable number of functions and add them to the init
@@ -152,7 +155,7 @@ declare namespace stampit {
          * @param statics Object(s) containing map of property names and values to mixin into each new stamp.
          * @return A new Stamp.
          */
-        statics(...statics: Array<{}>): Stamp<I>;
+        statics(...statics: Array<Specification.PropertyMap>): Stamp<I>;
 
         /**
          * Take n objects and add them to a new stamp and any future stamp it composes with.
@@ -160,7 +163,7 @@ declare namespace stampit {
          * @param statics Object(s) containing map of property names and values to mixin into each new stamp.
          * @return A new Stamp.
          */
-        staticProperties(...statics: Array<{}>): Stamp<I>;
+        staticProperties(...statics: Array<Specification.PropertyMap>): Stamp<I>;
 
         /**
          * Deeply merge a variable number of objects and add them to a new stamp and
@@ -169,7 +172,7 @@ declare namespace stampit {
          * merged
          * @returns A new stamp
          */
-        deepStatics(...deepStatics: Array<{}>): Stamp<I>;
+        deepStatics(...deepStatics: Array<Specification.PropertyMap>): Stamp<I>;
 
         /**
          * Deeply merge a variable number of objects and add them to a new stamp and
@@ -178,7 +181,7 @@ declare namespace stampit {
          * merged
          * @returns A new stamp
          */
-        staticDeepProperties(...deepStatics: Array<{}>): Stamp<I>;
+        staticDeepProperties(...deepStatics: Array<Specification.PropertyMap>): Stamp<I>;
 
         /**
          * Shallowly assign properties of Stamp arbitrary metadata and add them to
@@ -187,7 +190,7 @@ declare namespace stampit {
          * @param confs The object(s) containing metadata properties
          * @returns A new Stamp
          */
-        conf(...confs: Array<{}>): Stamp<I>;
+        conf(...confs: Array<Specification.PropertyMap>): Stamp<I>;
 
         /**
          * Shallowly assign properties of Stamp arbitrary metadata and add them to
@@ -196,7 +199,7 @@ declare namespace stampit {
          * @param confs The object(s) containing metadata properties
          * @returns A new Stamp
          */
-        configuration(...confs: Array<{}>): Stamp<I>;
+        configuration(...confs: Array<Specification.PropertyMap>): Stamp<I>;
 
         /**
          * Deeply merge properties of Stamp arbitrary metadata and add them to a new
@@ -205,7 +208,7 @@ declare namespace stampit {
          * @param deepConfs The object(s) containing metadata properties
          * @returns A new Stamp
          */
-        deepConf(...deepConfs: Array<{}>): Stamp<I>;
+        deepConf(...deepConfs: Array<Specification.PropertyMap>): Stamp<I>;
 
         /**
          * Deeply merge properties of Stamp arbitrary metadata and add them to a new
@@ -214,7 +217,7 @@ declare namespace stampit {
          * @param deepConfs The object(s) containing metadata properties
          * @returns A new Stamp
          */
-        deepConfiguration(...deepConfs: Array<{}>): Stamp<I>;
+        deepConfiguration(...deepConfs: Array<Specification.PropertyMap>): Stamp<I>;
 
         /**
          * Apply ES5 property descriptors to object instances created by the new
@@ -223,7 +226,7 @@ declare namespace stampit {
          * @param descriptors
          * @returns A new Stamp
          */
-        propertyDescriptors(...descriptors: Array<{}>): Stamp<I>;
+        propertyDescriptors(...descriptors: Array<PropertyDescriptorMap>): Stamp<I>;
 
         /**
          * Apply ES5 property descriptors to a Stamp and any future Stamp it
@@ -231,16 +234,13 @@ declare namespace stampit {
          * @param descriptors
          * @returns A new Stamp
          */
-        staticPropertyDescriptors(...descriptors: Array<{}>): Stamp<I>;
+        staticPropertyDescriptors(...descriptors: Array<PropertyDescriptorMap>): Stamp<I>;
     }
     /**
      * A shortcut methods for stampit().methods()
      * @param methods Object(s) containing map of method names and bodies for delegation.
      * @return A new Stamp.
      */
-    function methods
-    <I = any>
-    (...methods: Array<{}>): Stamp<I>;
     function methods
         <I = any>
         (...methods: Array<Specification.MethodMap>): Stamp<I>;
@@ -312,7 +312,7 @@ declare namespace stampit {
      * @return A new Stamp.
      */
     function staticProperties
-        <I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>>
+        <I = any, F extends Stamp<any> = Stamp<I>>
         (...statics: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
 
     /**
@@ -321,7 +321,7 @@ declare namespace stampit {
      * @return A new Stamp.
      */
     function staticProperties
-        <I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>>
+        <I = any, F extends Stamp<any> = Stamp<I>>
         (...statics: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
 
     /**
@@ -330,7 +330,7 @@ declare namespace stampit {
      * @returns A new stamp
      */
     function deepStatics
-        <I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>>
+        <I = any, F extends Stamp<any> = Stamp<I>>
         (...deepStatics: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
 
     /**
@@ -339,7 +339,7 @@ declare namespace stampit {
      * @returns A new stamp
      */
     function staticDeepProperties
-        <I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>>
+        <I = any, F extends Stamp<any> = Stamp<I>>
         (...deepStatics: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
 
     /**
@@ -348,7 +348,7 @@ declare namespace stampit {
      * @returns A new Stamp
      */
     function conf
-        <I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>>
+        <I = any, F extends Stamp<any> = Stamp<I>>
         (...deepConfs: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
 
     /**
@@ -357,7 +357,7 @@ declare namespace stampit {
      * @returns A new Stamp
      */
     function configuration
-        <I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>>
+        <I = any, F extends Stamp<any> = Stamp<I>>
         (...deepConfs: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
 
     /**
@@ -366,7 +366,7 @@ declare namespace stampit {
      * @returns A new Stamp
      */
     function deepConf
-        <I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>>
+        <I = any, F extends Stamp<any> = Stamp<I>>
         (...deepConfs: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
 
     /**
@@ -375,7 +375,7 @@ declare namespace stampit {
      * @returns A new Stamp
      */
     function deepConfiguration
-        <I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>>
+        <I = any, F extends Stamp<any> = Stamp<I>>
         (...deepConfs: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
 
     /**
@@ -393,7 +393,7 @@ declare namespace stampit {
      * @returns A new Stamp
      */
     function staticPropertyDescriptors
-        <I = any, F extends Specification.Stamp<any> = Specification.Stamp<I>>
+        <I = any, F extends Stamp<any> = Stamp<I>>
         (...descriptors: Array<PropertyDescriptorMap> & ThisType<F>): Stamp<I>;
 
     /**
@@ -404,7 +404,7 @@ declare namespace stampit {
      */
     function compose
         <I = any>
-        (...composables: Array<StampitComposable<I>>): Stamp<I>;
+        (...composables: Array<Composable<I>>): Stamp<I>;
 }
 
 // export = stampit;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,414 @@
+// Type definitions for stampit 4.3
+// Project: https://github.com/stampit-org/stampit, https://stampit.js.org
+// Definitions by: Vasyl Boroviak <https://github.com/koresar>
+//                 Harris Lummis <https://github.com/lummish>
+//                 PopGoesTheWza <https://github.com/popgoesthewza>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="specification.d.ts" />
+
+/**
+ * Return a factory (a.k.a. Stamp) function that will produce new objects using the prototypes that are passed in or composed.
+ * @param options Stampit options object containing methods,
+ * init, props, statics, configurations, and property descriptors.
+ */
+declare function stampit<I = any>(...composables: Array<stampit.StampitComposable<I>>): stampit.Stamp<I>;
+
+declare namespace stampit {
+    // TODO: Add description
+    const version: string;
+    /** The stamp Descriptor */
+    interface Descriptor<I, F extends Specification.Factory<any> = Specification.Factory<I>> extends Specification.Descriptor<I, F> {
+        /** Create a new stamp based on this descriptor */
+        // ? is this function signature trully needed?
+        (...composables: Array<StampitComposable<I>>): Stamp<I>;
+    }
+
+    /** Any composable object (stamp or descriptor) */
+    // ! should have been StampitComposable
+    // type Composable<I> = Stamp<I> | Descriptor<I>;
+
+    // TODO: Add description
+    // ? shouldn't stampit.Option be stampit.(Extended)Descriptor really?
+    interface Options<I, F extends Specification.Factory<any> = Specification.Factory<I>> extends Omit<Specification.Descriptor<I, F>, 'initializers'> {
+        /** Properties which will shallowly copied into any future created instance. */
+        props?: Specification.PropertyMap;
+        /** Deeply merged properties of object instances */
+        deepProps?: Specification.PropertyMap;
+        /** Properties which will be mixed to the new and any other stamp which this stamp will be composed with. */
+        statics?: Specification.PropertyMap & ThisType<F>;
+        /** Deeply merged properties of Stamps */
+        deepStatics?: Specification.PropertyMap & ThisType<F>;
+        /** Initialization function(s) which will be called per each newly created instance. */
+        init?: Specification.Initializer<I> | Array<Specification.Initializer<I>>;
+        /** Initialization function(s) which will be called per each newly created instance. */
+        initializers?: Specification.Initializer<I> | Array<Specification.Initializer<I>>;
+        /** A configuration object to be shallowly assigned to Stamps */
+        conf?: Specification.PropertyMap & ThisType<F>;
+        /** A configuration object to be deeply merged to Stamps */
+        deepConf?: Specification.PropertyMap & ThisType<F>;
+        // TODO: Add description
+        name: string;
+    }
+
+    /** Stampit Composable for main stampit() function */
+    // TODO: simplify after factorizing interfaces
+    type StampitComposable<I, U = Specification.StampType<I>> = Specification.Composable<I, U> | Stamp<I> | Descriptor<U> | Options<U>;
+
+    /**
+     * A factory function that will produce new objects using the
+     * prototypes that are passed in or composed.
+     */
+    interface Stamp<I = any, F extends Specification.Factory<any> = Specification.Factory<I>> extends Specification.Factory<I> {
+        /**
+         * Just like calling stamp(), stamp.create() invokes the stamp and returns a new instance.
+         * @param state Properties you wish to set on the new objects.
+         * @param encloseArgs The remaining arguments are passed to all `.init()` functions.
+         * **WARNING** Avoid using two different `.init()` functions that expect different arguments.
+         * `.init()` functions that take arguments should not be considered safe to compose
+         * with other `.init()` functions that also take arguments. Taking arguments with
+         * an `.init()` function is an anti-pattern that should be avoided, when possible.
+         * @return A new object composed of the Stamps and prototypes provided.
+         */
+        create(state?: Specification.PropertyMap, ...encloseArgs: Array<any>): I;
+
+        /**
+         * Stamp metadata/composer function
+         */
+        compose: Descriptor<I> & Specification.ComposeMethod<I>;
+
+        /**
+         * Add methods to the methods prototype.  Creates and returns new Stamp. Chainable.
+         * @param methods Object(s) containing map of method names and bodies for delegation.
+         * @return A new Stamp.
+         */
+        methods(...methods: Array<{}>): Stamp<I>;
+
+        /**
+         * Take a variable number of objects and shallow assign them to any future
+         * created instance of the Stamp. Creates and returns new Stamp. Chainable.
+         * @param objects Object(s) to shallow assign for each new object.
+         * @return A new Stamp.
+         */
+        props(...objects: Array<{}>): Stamp<I>;
+
+        /**
+         * Take a variable number of objects and shallow assign them to any future
+         * created instance of the Stamp. Creates and returns new Stamp. Chainable.
+         * @param objects Object(s) to shallow assign for each new object.
+         * @return A new Stamp.
+         */
+        properties(...objects: Array<{}>): Stamp<I>;
+
+        /**
+         * Take a variable number of objects and deeply merge them to any future
+         * created instance of the Stamp. Creates and returns a new Stamp.
+         * Chainable.
+         * @param deepObjects The object(s) to deeply merge for each new object
+         * @returns A new Stamp
+         */
+        deepProps(...deepObjects: Array<{}>): Stamp<I>;
+
+        /**
+         * Take a variable number of objects and deeply merge them to any future
+         * created instance of the Stamp. Creates and returns a new Stamp.
+         * Chainable.
+         * @param deepObjects The object(s) to deeply merge for each new object
+         * @returns A new Stamp
+         */
+        deepProperties(...deepObjects: Array<{}>): Stamp<I>;
+
+        /**
+         * Take in a variable number of functions and add them to the init
+         * prototype as initializers.
+         * @param functions Initializer functions used to create private data and
+         * privileged methods
+         * @returns A new stamp
+         */
+        init<I = any>(...functions: Array<Specification.Initializer<I>>): Stamp<I>;
+        init<I = any>(functions: Array<Specification.Initializer<I>>): Stamp<I>;
+
+        /**
+         * Take in a variable number of functions and add them to the init
+         * prototype as initializers.
+         * @param functions Initializer functions used to create private data and
+         * privileged methods
+         * @returns A new stamp
+         */
+        initializers<I>(...functions: Array<Specification.Initializer<I>>): Stamp<I>;
+
+        /**
+         * Take in a variable number of functions and add them to the init
+         * prototype as initializers.
+         * @param functions Initializer functions used to create private data and
+         * privileged methods
+         * @returns A new stamp
+         */
+        initializers<I>(functions: Array<Specification.Initializer<I>>): Stamp<I>;
+
+        /**
+         * Take n objects and add them to a new stamp and any future stamp it composes with.
+         * Creates and returns new Stamp. Chainable.
+         * @param statics Object(s) containing map of property names and values to mixin into each new stamp.
+         * @return A new Stamp.
+         */
+        statics(...statics: Array<{}>): Stamp<I>;
+
+        /**
+         * Take n objects and add them to a new stamp and any future stamp it composes with.
+         * Creates and returns new Stamp. Chainable.
+         * @param statics Object(s) containing map of property names and values to mixin into each new stamp.
+         * @return A new Stamp.
+         */
+        staticProperties(...statics: Array<{}>): Stamp<I>;
+
+        /**
+         * Deeply merge a variable number of objects and add them to a new stamp and
+         * any future stamp it composes. Creates and returns a new Stamp. Chainable.
+         * @param deepStatics The object(s) containing static properties to be
+         * merged
+         * @returns A new stamp
+         */
+        deepStatics(...deepStatics: Array<{}>): Stamp<I>;
+
+        /**
+         * Deeply merge a variable number of objects and add them to a new stamp and
+         * any future stamp it composes. Creates and returns a new Stamp. Chainable.
+         * @param deepStatics The object(s) containing static properties to be
+         * merged
+         * @returns A new stamp
+         */
+        staticDeepProperties(...deepStatics: Array<{}>): Stamp<I>;
+
+        /**
+         * Shallowly assign properties of Stamp arbitrary metadata and add them to
+         * a new stamp and any future Stamp it composes. Creates and returns a new
+         * Stamp. Chainable.
+         * @param confs The object(s) containing metadata properties
+         * @returns A new Stamp
+         */
+        conf(...confs: Array<{}>): Stamp<I>;
+
+        /**
+         * Shallowly assign properties of Stamp arbitrary metadata and add them to
+         * a new stamp and any future Stamp it composes. Creates and returns a new
+         * Stamp. Chainable.
+         * @param confs The object(s) containing metadata properties
+         * @returns A new Stamp
+         */
+        configuration(...confs: Array<{}>): Stamp<I>;
+
+        /**
+         * Deeply merge properties of Stamp arbitrary metadata and add them to a new
+         * Stamp and any future Stamp it composes. Creates and returns a new Stamp.
+         * Chainable.
+         * @param deepConfs The object(s) containing metadata properties
+         * @returns A new Stamp
+         */
+        deepConf(...deepConfs: Array<{}>): Stamp<I>;
+
+        /**
+         * Deeply merge properties of Stamp arbitrary metadata and add them to a new
+         * Stamp and any future Stamp it composes. Creates and returns a new Stamp.
+         * Chainable.
+         * @param deepConfs The object(s) containing metadata properties
+         * @returns A new Stamp
+         */
+        deepConfiguration(...deepConfs: Array<{}>): Stamp<I>;
+
+        /**
+         * Apply ES5 property descriptors to object instances created by the new
+         * Stamp returned by the function and any future Stamp it composes. Creates
+         * and returns a new stamp. Chainable.
+         * @param descriptors
+         * @returns A new Stamp
+         */
+        propertyDescriptors(...descriptors: Array<{}>): Stamp<I>;
+
+        /**
+         * Apply ES5 property descriptors to a Stamp and any future Stamp it
+         * composes. Creates and returns a new stamp. Chainable.
+         * @param descriptors
+         * @returns A new Stamp
+         */
+        staticPropertyDescriptors(...descriptors: Array<{}>): Stamp<I>;
+    }
+    /**
+     * A shortcut methods for stampit().methods()
+     * @param methods Object(s) containing map of method names and bodies for delegation.
+     * @return A new Stamp.
+     */
+    function methods
+    <I = any>
+    (...methods: Array<{}>): Stamp<I>;
+    function methods
+        <I = any>
+        (...methods: Array<Specification.MethodMap>): Stamp<I>;
+
+    /**
+     * A shortcut method for stampit().props()
+     * @param objects Object(s) to shallow assign for each new object.
+     * @return A new Stamp.
+     */
+    function props
+        <I = any>
+        (...objects: Array<Specification.PropertyMap>): Stamp<I>;
+
+    /**
+     * A shortcut method for stampit().properties()
+     * @param objects Object(s) to shallow assign for each new object.
+     * @return A new Stamp.
+     */
+    function properties
+        <I = any>
+        (...objects: Array<Specification.PropertyMap>): Stamp<I>;
+
+    /**
+     * A shortcut method for stampit().deepProps()
+     * @param deepObjects The object(s) to deeply merge for each new object
+     * @returns A new Stamp
+     */
+    function deepProps
+        <I = any>
+        (...deepObjects: Array<Specification.PropertyMap>): Stamp<I>;
+
+    /**
+     * A shortcut method for stampit().deepProperties()
+     * @param deepObjects The object(s) to deeply merge for each new object
+     * @returns A new Stamp
+     */
+    function deepProperties
+        <I = any>
+        (...deepObjects: Array<Specification.PropertyMap>): Stamp<I>;
+
+    /**
+     * A shortcut method for stampit().init()
+     * @param functions Initializer functions used to create private data and
+     * privileged methods
+     * @returns A new stamp
+     */
+    function init
+        <I = any>
+        (...functions: Array<Specification.Initializer<I>>): Stamp<I>;
+    function init
+        <I = any>
+        (...functions: Array<Specification.Initializer<I>>): Stamp<I>;
+
+    /**
+     * A shortcut method for stampit().initializers()
+     * @param functions Initializer functions used to create private data and privileged methods
+     * @returns A new stamp
+     */
+    function initializers
+        <I = any>
+        (...functions: Array<Specification.Initializer<I>>): Stamp<I>;
+    function initializers
+        <I = any>
+        (...functions: Array<Specification.Initializer<I>>): Stamp<I>;
+
+    /**
+     * A shortcut method for stampit().statics()
+     * @param statics Object(s) containing map of property names and values to mixin into each new stamp.
+     * @return A new Stamp.
+     */
+    function staticProperties
+        <I = any, F extends Specification.Factory<any> = Specification.Factory<I>>
+        (...statics: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
+
+    /**
+     * A shortcut method for stampit().staticProperties()
+     * @param statics Object(s) containing map of property names and values to mixin into each new stamp.
+     * @return A new Stamp.
+     */
+    function staticProperties
+        <I = any, F extends Specification.Factory<any> = Specification.Factory<I>>
+        (...statics: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
+
+    /**
+     * A shortcut method for stampit().deepStatics()
+     * @param deepStatics The object(s) containing static properties to be merged
+     * @returns A new stamp
+     */
+    function deepStatics
+        <I = any, F extends Specification.Factory<any> = Specification.Factory<I>>
+        (...deepStatics: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
+
+    /**
+     * A shortcut method for stampit().staticDeepProperties()
+     * @param deepStatics The object(s) containing static properties to be merged
+     * @returns A new stamp
+     */
+    function staticDeepProperties
+        <I = any, F extends Specification.Factory<any> = Specification.Factory<I>>
+        (...deepStatics: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
+
+    /**
+     * A shortcut method for stampit().conf()
+     * @param confs The object(s) containing metadata properties
+     * @returns A new Stamp
+     */
+    function conf
+        <I = any, F extends Specification.Factory<any> = Specification.Factory<I>>
+        (...deepConfs: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
+
+    /**
+     * A shortcut method for stampit().configuration()
+     * @param confs The object(s) containing metadata properties
+     * @returns A new Stamp
+     */
+    function configuration
+        <I = any, F extends Specification.Factory<any> = Specification.Factory<I>>
+        (...deepConfs: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
+
+    /**
+     * A shortcut method for stampit().deepConf()
+     * @param deepConfs The object(s) containing metadata properties
+     * @returns A new Stamp
+     */
+    function deepConf
+        <I = any, F extends Specification.Factory<any> = Specification.Factory<I>>
+        (...deepConfs: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
+
+    /**
+     * A shortcut method for stampit().deepConfiguration()
+     * @param deepConfs The object(s) containing metadata properties
+     * @returns A new Stamp
+     */
+    function deepConfiguration
+        <I = any, F extends Specification.Factory<any> = Specification.Factory<I>>
+        (...deepConfs: Array<Specification.PropertyMap> & ThisType<F>): Stamp<I>;
+
+    /**
+     * A shortcut method for stampit().propertyDescriptors()
+     * @param descriptors
+     * @returns A new Stamp
+     */
+    function propertyDescriptors
+        <I = any>
+        (...descriptors: Array<PropertyDescriptorMap>): Stamp<I>;
+
+    /**
+     * A shortcut method for stampit().staticPropertyDescriptors()
+     * @param descriptors
+     * @returns A new Stamp
+     */
+    function staticPropertyDescriptors
+        <I = any, F extends Specification.Factory<any> = Specification.Factory<I>>
+        (...descriptors: Array<PropertyDescriptorMap> & ThisType<F>): Stamp<I>;
+
+    /**
+     * Take two or more Composables and combine them to produce a new Stamp.
+     * Combining overrides properties with last-in priority.
+     * @param composables Composable objects used to create the stamp.
+     * @return A new Stamp made of all the given composables.
+     */
+    function compose
+        <I = any>
+        (...composables: Array<StampitComposable<I>>): Stamp<I>;
+}
+
+// export = stampit;
+
+declare module 'stampit' {
+    export = stampit;
+}

--- a/types/specification.d.ts
+++ b/types/specification.d.ts
@@ -1,0 +1,105 @@
+/** Stamp Specification v1.6 */
+declare namespace Specification {
+  /** Base type for `properties` */
+  type PropertyMap = { [s: string]: any; };
+
+  /** Base type for `methods` */
+  type MethodMap = { [s: string]: (...args: Array<any>) => any; };
+
+  /** Extract the instance type from Factory, Descriptor (or Instance) */
+  type StampType<I> = I extends Factory<infer I> ? I
+                    : I extends Descriptor<infer I> ? I
+                    : I extends Instance ? I
+                    : never;
+
+  /** A composable object (`stamp` factory or Descriptor) */
+  type Composable<I, U = StampType<I>> = Factory<U> | Descriptor<U>;
+
+  /** Base `stamp` instance */
+  type Instance = { [s: string]: any; };
+
+  /**
+   * A factory function that will produce new objects using the
+   * prototypes that are passed in or composed.
+   */
+  // TODO: interface Factory<I, F extends Factory<any> = Factory<I>>
+  interface Factory<I> {
+      /**
+       * Invokes the `stamp` and returns a new object instance.
+       * @param options Properties you wish to set on the new object.
+       * @param args The remaining arguments are passed to all `.init()` functions.
+       * **WARNING** Avoid using two different `.init()` functions that expect different arguments.
+       * `.init()` functions that take arguments should not be considered safe to compose
+       * with other `.init()` functions that also take arguments. Taking arguments with
+       * an `.init()` function is an anti-pattern that should be avoided, when possible.
+       * @return A new object composed of the Stamps and prototypes provided.
+       */
+      (options?: PropertyMap, ...args: Array<any>): I;
+
+      /** Stamp metadata/composer function */
+      compose: ComposeMethod<I> & Descriptor<I>;
+  }
+
+  /** Create a new stamp based on this descriptor */
+  interface ComposeMethod<I> {
+      // TODO: investigate how to support extended Factory interfaces
+      <U>(...args: Array<U>): Factory<I & StampType<U>>;
+  }
+
+  /** The stamp Descriptor */
+  interface Descriptor<I, F extends Factory<any> = Factory<I>> {
+      /** A hash containing methods (functions) of any future created instance. */
+      methods?: MethodMap;
+      /** Properties which will shallowly copied into any future created instance. */
+      properties?: PropertyMap;
+      /** Deeply merged properties of object instances */
+      deepProperties?: PropertyMap;
+      /** ES5 Property Descriptors applied to object instances */
+      propertyDescriptors?: PropertyDescriptorMap;
+      /** Properties which will be mixed to the new and any other stamp which this stamp will be composed with. */
+      staticProperties?: PropertyMap & ThisType<F>;
+      /** Deeply merged properties of Stamps */
+      staticDeepProperties?: PropertyMap & ThisType<F>;
+      /** ES5 Property Descriptors applied to Stamps */
+      staticPropertyDescriptors?: PropertyDescriptorMap & ThisType<F>;
+      /** Initialization function(s) which will be called per each newly created instance. */
+      initializers?: Array<Initializer<I>>;
+      /** Callback functions to execute each time a composition occurs */
+      composers?: Array<Composer<I>>;
+      /** A configuration object to be shallowly assigned to Stamps */
+      configuration?: PropertyMap & ThisType<F>;
+      /** A configuration object to be deeply merged to Stamps */
+      deepConfiguration?: PropertyMap & ThisType<F>;
+  }
+
+  /** Function used as .init() argument. */
+  interface Initializer<I> {
+      // TODO: check that the value of `this` is correct
+      (/*this: I, */options: PropertyMap, context?: InitializerContext<I>): any;
+  }
+
+  /** The .init() function argument. */
+  interface InitializerContext<I> {
+      /** The object instance being produced by the stamp. If the initializer returns a value other than `undefined`, it replaces the instance. */
+      instance?: I;
+      /** A reference to the `stamp` producing the instance. */
+      // TODO: investigate how to support extended Factory interfaces
+      stamp?: Factory<I>;
+      /** An array of the arguments passed into the stamp, including the `options` argument. */
+      // ! above description from the specification is obscure
+      args?: Array<any>;
+  }
+
+  /** Composer function */
+  interface Composer<I> {
+      (parmeters: ComposerParameters<I>): Factory<I>;
+  }
+
+  interface ComposerParameters<I> {
+      /** The result of the composables composition. */
+      // TODO: investigate how to support extended Factory interfaces
+      stamp: Factory<I>;
+      /** The list of composables the `stamp` was just composed of. */
+      composables: Array<Composable<I>>;
+  }
+}

--- a/types/specification.d.ts
+++ b/types/specification.d.ts
@@ -1,105 +1,151 @@
 /** Stamp Specification v1.6 */
 declare namespace Specification {
-  /** Base type for `properties` */
+  /** Base type for all `properties`-like metadata. */
   type PropertyMap = { [s: string]: any; };
 
-  /** Base type for `methods` */
+  /** Base type for all `methods`-like metadata. */
   type MethodMap = { [s: string]: (...args: Array<any>) => any; };
 
-  /** Extract the instance type from Factory, Descriptor (or Instance) */
-  type StampType<I> = I extends Factory<infer I> ? I
+  /**
+   * Extract the type of the object defined by `Stamp`, `Descriptor` (or `POJO`) types.
+   * @param {type} I Type definition to extract the object type from.
+   * @returns {type} The object type.
+   */
+  type StampType<I> = I extends Stamp<infer I> ? I
                     : I extends Descriptor<infer I> ? I
-                    : I extends Instance ? I
+                    : I extends POJO ? I
                     : never;
 
-  /** A composable object (`stamp` factory or Descriptor) */
-  type Composable<I, U = StampType<I>> = Factory<U> | Descriptor<U>;
+  /**
+   * A composable object (either a `Stamp` or a `Descriptor`)
+   * @param {type} I The object type defined by `Stamp` or `Descriptor` types.
+   * @returns {type} The composable type.
+   */
+  // TODO: support for extended `Stamp` interfaces
+  type Composable<I, U = StampType<I>> = Stamp<U> | Descriptor<U>;
 
-  /** Base `stamp` instance */
-  type Instance = { [s: string]: any; };
+  /** A plain old JavaScript object created from a `Stamp`. */
+  type POJO = { [s: string]: any; };
 
   /**
-   * A factory function that will produce new objects using the
-   * prototypes that are passed in or composed.
+   * A factory function to create plain object instances. It also has a `.compose()` method which is a copy of the `ComposeMethod` function.
+   * @param {type} I The object type produced by the `Stamp`.
+   * @returns {I} The object produced by the `Stamp`.
    */
-  // TODO: interface Factory<I, F extends Factory<any> = Factory<I>>
-  interface Factory<I> {
+  // TODO: support for extending a `Stamp` factory: interface Stamp<I, F extends Stamp<any> = Stamp<I>>
+  interface Stamp<I> {
       /**
-       * Invokes the `stamp` and returns a new object instance.
-       * @param options Properties you wish to set on the new object.
-       * @param args The remaining arguments are passed to all `.init()` functions.
-       * **WARNING** Avoid using two different `.init()` functions that expect different arguments.
-       * `.init()` functions that take arguments should not be considered safe to compose
-       * with other `.init()` functions that also take arguments. Taking arguments with
-       * an `.init()` function is an anti-pattern that should be avoided, when possible.
-       * @return A new object composed of the Stamps and prototypes provided.
+       * @param {type} I The object type produced by the `Stamp`.
+       * @param {PropertyMap} options (optional) Properties to set on the new object instance.
+       * @param {Array<any>} args Remaining arguments passed to all `.initializers` functions.
+       * **WARNING** Avoid using different `.initializers` functions that expect different arguments.
+       * `.initializers` functions that take arguments should not be considered safe to compose
+       * with other `.initializers` functions that also take arguments. Taking arguments with
+       * an `.initializers` function is an anti-pattern that should be avoided, when possible.
+       * @returns {I} The object produced by the `Stamp`.
        */
       (options?: PropertyMap, ...args: Array<any>): I;
 
-      /** Stamp metadata/composer function */
+      /** Stamp `ComposeMethod` function and `Descriptor` metadata. */
       compose: ComposeMethod<I> & Descriptor<I>;
   }
 
-  /** Create a new stamp based on this descriptor */
+  /**
+   * A function which creates a new `Stamp`s from a list of `Composable`s.
+   * @param {type} U The object type produced by the new `Stamp`.
+   * @param {Array<Composable>} args A list of `Composable`s.
+   * @returns {Stamp} The new `Stamp`.
+   */
   interface ComposeMethod<I> {
-      // TODO: investigate how to support extended Factory interfaces
-      <U>(...args: Array<U>): Factory<I & StampType<U>>;
+      // TODO: support for extended `Stamp` interfaces
+      // TODO: compose final object type from StampType<args> & StampType<U>
+      // ? is the `Descriptor` from the source `Stamp` also used in the composition
+      <U>(...args: Array<Composable<any>>): Stamp<StampType<U>>;
   }
 
-  /** The stamp Descriptor */
-  interface Descriptor<I, F extends Factory<any> = Factory<I>> {
-      /** A hash containing methods (functions) of any future created instance. */
+  /**
+   * A `Stamp`'s metadata
+   * @param {type} I The object type produced by the `Stamp`.
+   * @param {type} F (optional) The extended `Stamp` type.
+   */
+  interface Descriptor<I, F extends Stamp<any> = Stamp<I>> {
+      /** A set of methods that will be added to the object's delegate prototype. */
       methods?: MethodMap;
-      /** Properties which will shallowly copied into any future created instance. */
+      /** A set of properties that will be added to new object instances by assignment. */
       properties?: PropertyMap;
-      /** Deeply merged properties of object instances */
+      /** A set of properties that will be added to new object instances by deep property merge. */
       deepProperties?: PropertyMap;
-      /** ES5 Property Descriptors applied to object instances */
+      /** A set of object property descriptors (`PropertyDescriptor`) used for fine-grained control over object property behaviors. */
       propertyDescriptors?: PropertyDescriptorMap;
-      /** Properties which will be mixed to the new and any other stamp which this stamp will be composed with. */
+      /** A set of static properties that will be copied by assignment to the `Stamp`. */
       staticProperties?: PropertyMap & ThisType<F>;
-      /** Deeply merged properties of Stamps */
+      /** A set of static properties that will be added to the `Stamp` by deep property merge. */
       staticDeepProperties?: PropertyMap & ThisType<F>;
-      /** ES5 Property Descriptors applied to Stamps */
+      /** A set of object property descriptors (`PropertyDescriptor`) to apply to the `Stamp`. */
       staticPropertyDescriptors?: PropertyDescriptorMap & ThisType<F>;
-      /** Initialization function(s) which will be called per each newly created instance. */
+      /** An array of functions that will run in sequence while creating an object instance from a `Stamp`. `Stamp` details and arguments get passed to initializers. */
       initializers?: Array<Initializer<I>>;
-      /** Callback functions to execute each time a composition occurs */
+      /** An array of functions that will run in sequence while creating a new `Stamp` from a list of `Composable`s. The resulting `Stamp` and the `Composable`s get passed to composers. */
       composers?: Array<Composer<I>>;
-      /** A configuration object to be shallowly assigned to Stamps */
+      /** A set of options made available to the `Stamp` and its initializers during object instance creation. These will be copied by assignment. */
       configuration?: PropertyMap & ThisType<F>;
-      /** A configuration object to be deeply merged to Stamps */
+      /** A set of options made available to the `Stamp` and its initializers during object instance creation. These will be deep merged. */
       deepConfiguration?: PropertyMap & ThisType<F>;
   }
 
-  /** Function used as .init() argument. */
+  /**
+   * A function used as `.initializers` argument.
+   * @param {type} I The object type produced by the `Stamp`.
+   * @param {PropertyMap} options The `options` argument passed into the stamp, containing properties that may be used by initializers.
+   * (Cf. the `Descriptor` attributes `configuration` and `deepConfiguration`)
+   * @param {InitializerContext} context (optional) The context of current `.initializers` function.
+   * @returns {I} The object produced by the `Stamp`.
+   */
   interface Initializer<I> {
       // TODO: check that the value of `this` is correct
-      (/*this: I, */options: PropertyMap, context?: InitializerContext<I>): any;
+      (/*this: I, */options?: PropertyMap, context?: InitializerContext<I>): I;
   }
 
-  /** The .init() function argument. */
+  /**
+   * The `Initializer` function context.
+   * @param {type} I The object type produced by the `Stamp`.
+   * @param {I} instance (optional) The object instance being produced by the `Stamp`. If the initializer returns a value other than `undefined`, it replaces the instance.
+   * @param {Stamp<I>} stamp (optional) A reference to the `Stamp` producing the instance.
+   * @param {Array<any>} args (optional) An array of the arguments passed into the `Stamp`, including the options argument.
+   */
   interface InitializerContext<I> {
-      /** The object instance being produced by the stamp. If the initializer returns a value other than `undefined`, it replaces the instance. */
+      /** The object instance being produced by the `Stamp`. If the initializer returns a value other than `undefined`, it replaces the instance. */
       instance?: I;
-      /** A reference to the `stamp` producing the instance. */
-      // TODO: investigate how to support extended Factory interfaces
-      stamp?: Factory<I>;
-      /** An array of the arguments passed into the stamp, including the `options` argument. */
+      /** A reference to the `Stamp` producing the instance. */
+      // TODO: investigate how to support extended Stamp interfaces
+      stamp?: Stamp<I>;
+      /** An array of the arguments passed into the `Stamp`, including the options argument. */
       // ! above description from the specification is obscure
       args?: Array<any>;
   }
 
-  /** Composer function */
+  /**
+   * A function used as `.composers` argument.
+   * @param {type} I The object type produced by the new `Stamp`.
+   * @param {ComposerParameters} parameters The parameters recieved by the current `.composers` function.
+   * @returns {Stamp<I>} The new `Stamp`.
+   */
   interface Composer<I> {
-      (parmeters: ComposerParameters<I>): Factory<I>;
+      (parameters: ComposerParameters<I>): Stamp<I>;
   }
 
+  /**
+   * The parameters recieved by the current `.composers` function.
+   * @param {type} I The object type produced by the new `Stamp`.
+   * @param {Stamp<I>} stamp The result of the `Composable`s composition.
+   * @param {Array<Composable>} composables The list of composables the `Stamp` was just composed of.
+   */
   interface ComposerParameters<I> {
-      /** The result of the composables composition. */
-      // TODO: investigate how to support extended Factory interfaces
-      stamp: Factory<I>;
-      /** The list of composables the `stamp` was just composed of. */
-      composables: Array<Composable<I>>;
+      /** The result of the `Composable`s composition. */
+      // TODO: investigate how to support extended Stamp interfaces
+      stamp: Stamp<I>;
+      /** The list of composables the `Stamp` was just composed of. */
+      // TODO: better typing of Composable
+      composables: Array<Composable<any>>;
   }
 }


### PR DESCRIPTION
Issue #245 [Work In Progress]

Types are broken down into two files

- `specification.d.ts` attempts to follow strictly Stamp Specification v1.6
- `index.d.ts` exposes `stampit` extended implementation

For review:

- lookout for  special comments `// ?`, `// !` and `// TODO`

Sample code

```ts
import stampit, { compose, init } from 'stampit';

// default instance type (any)

const a = stampit().init(function(options) {
  const a = options.args[0];
  this.getA = () => {
    return a;
  };
});
a(); // Object -- so far so good.
a().getA(); // "a"

// typed instances

  interface CoordsInstance {
    x: number;
    y: number;
    coordsToString: () => string;
  }

  interface ColorInstance {
    color: string;
  }

  const Coords = compose<CoordsInstance>({
    initializers: [
      function({ x, y }) {
        this.x = x;
        this.y = y;
      },
    ],
    methods: {
      coordsToString() {
        return `(${this.x}, ${this.y})`;
      },
    },
  });
  const Point = compose<CoordsInstance & { toString: () => string }>(
    Coords,
    {
      methods: {
        toString() {
          return this.coordsToString();
        },
      },
    },
  );
  const Color = compose<ColorInstance>({
    initializers: [
      function({ color }) {
        this.color = color;
      },
    ],
  });
```
