### PR TITLE
Introducing Stampit Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img src="https://raw.githubusercontent.com/stampit-org/stampit-logo/master/stampit-logo.png" alt="stampit" width="160" />
 </p>
 
-# Stampit [![npm](https://img.shields.io/npm/dm/stampit.svg)](https://www.npmjs.com/package/stampit) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/stampit-org/stampit?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Twitter Follow](https://img.shields.io/twitter/follow/stampit.svg?style=social&label=Follow&maxAge=2592000)](https://twitter.com/stampit_org) [![UNPKG](https://img.shields.io/badge/gzip%20size-1.4%20kB-brightgreen.svg)](https://unpkg.com/stampit@latest/dist/stampit.min.js)
+# Stampit [![npm](https://img.shields.io/npm/dm/stampit.svg)](https://www.npmjs.com/package/stampit) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/stampit-org/stampit?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Twitter Follow](https://img.shields.io/twitter/follow/stampit.svg?style=social&label=Follow&maxAge=2592000)](https://twitter.com/stampit_org) [![UNPKG](https://img.shields.io/badge/gzip%20size-1.4%20kB-brightgreen.svg)](https://unpkg.com/stampit@latest/dist/stampit.min.js) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Stampit%20Guru-006BFF)](https://gurubase.io/g/stampit)
 
 **Create objects from reusable, composable behaviors** 
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Stampit Guru](https://gurubase.io/g/stampit) to Gurubase. Stampit Guru uses the data from this repo and data from the [docs](https://stampit.js.org) to answer questions by leveraging the LLM.

In this PR, I showcased the "Stampit Guru", which highlights that Stampit now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Stampit Guru in Gurubase, just let me know that's totally fine.
